### PR TITLE
Add addon name to log messages

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -11,8 +11,10 @@ pub fn arcdps_export(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let sig = input.sig;
     let build = std::env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION is not set") + "\0";
     let build = syn::LitStr::new(build.as_str(), Span::call_site());
-    let name = input.name.value() + "\0";
+    let name = input.name.value();
     let name = syn::LitStr::new(name.as_str(), input.name.span());
+    let out_name = input.name.value() + "\0";
+    let out_name = syn::LitStr::new(out_name.as_str(), input.name.span());
 
     let (abstract_combat, cb_combat) = build_combat(input.raw_combat, input.combat);
     let (abstract_combat_local, cb_combat_local) =
@@ -33,7 +35,7 @@ pub fn arcdps_export(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
             sig: #sig,
             imgui_version: 18000,
             out_build: #build.as_ptr(),
-            out_name: #name.as_ptr(),
+            out_name: #out_name.as_ptr(),
             combat: #cb_combat,
             combat_local: #cb_combat_local,
             imgui: #cb_imgui,
@@ -109,7 +111,7 @@ pub fn arcdps_export(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
                 imgui::sys::igSetAllocatorFunctions(mallocfn, freefn, ::core::ptr::null_mut());
                 CTX = Some(imgui::Context::current());
                 UI = Some(imgui::Ui::from_ctx(CTX.as_ref().unwrap()));
-                ::arcdps::__init(arcdll);
+                ::arcdps::__init(arcdll, #name);
                 load
             }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,7 @@ git = "https://github.com/greaka/imgui-rs"
 [dependencies.log]
 version = "0.4"
 optional = true
+features = ["std"]
 
 [features]
 default = ["log"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,6 +20,8 @@ pub unsafe fn __init(arcdps: raw_structs::HANDLE, name: &'static str) {
     #[cfg(feature = "log")]
     let _ = log::set_boxed_logger(Box::new(logging::ArcdpsLogger::new(name)))
         .map(|()| log::set_max_level(log::LevelFilter::Trace));
+    #[cfg(not(feature="log"))]
+    let _ = name;   // only used for logging
 }
 
 /// This struct isn't used anywhere. It is a reference on what fields are

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,10 +15,11 @@ pub use imgui;
 
 #[doc(hidden)]
 #[inline(always)]
-pub unsafe fn __init(arcdps: raw_structs::HANDLE) {
+pub unsafe fn __init(arcdps: raw_structs::HANDLE, name: &'static str) {
     __set_handle(arcdps);
     #[cfg(feature = "log")]
-    let _ = log::set_logger(&logging::LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace));
+    let _ = log::set_boxed_logger(Box::new(logging::ArcdpsLogger::new(name)))
+        .map(|()| log::set_max_level(log::LevelFilter::Trace));
 }
 
 /// This struct isn't used anywhere. It is a reference on what fields are

--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -1,9 +1,15 @@
 use crate::{e3, e8};
 use log::{Metadata, Record};
 
-pub(crate) static LOGGER: ArcdpsLogger = ArcdpsLogger;
+pub(crate) struct ArcdpsLogger {
+    name: &'static str,
+}
 
-pub(crate) struct ArcdpsLogger;
+impl ArcdpsLogger {
+    pub(crate) fn new(name: &'static str) -> Self {
+        Self { name }
+    }
+}
 
 impl log::Log for ArcdpsLogger {
     fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
@@ -11,14 +17,16 @@ impl log::Log for ArcdpsLogger {
     }
 
     fn log(&self, record: &Record<'_>) {
-        ArcdpsFileLogger::log(&ArcdpsFileLogger, record);
-        ArcdpsWindowLogger::log(&ArcdpsWindowLogger, record);
+        ArcdpsFileLogger::log(&ArcdpsFileLogger { name: self.name }, record);
+        ArcdpsWindowLogger::log(&ArcdpsWindowLogger { name: self.name }, record);
     }
 
     fn flush(&self) {}
 }
 
-struct ArcdpsFileLogger;
+struct ArcdpsFileLogger {
+    name: &'static str,
+}
 
 impl log::Log for ArcdpsFileLogger {
     fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
@@ -27,7 +35,8 @@ impl log::Log for ArcdpsFileLogger {
 
     fn log(&self, record: &Record<'_>) {
         let body = format!(
-            "{}:{} {}: {}\0",
+            "{} - {}:{} {}: {}\0",
+            self.name,
             record.file().unwrap_or_default(),
             record.line().unwrap_or_default(),
             record.level(),
@@ -39,7 +48,9 @@ impl log::Log for ArcdpsFileLogger {
     fn flush(&self) {}
 }
 
-struct ArcdpsWindowLogger;
+struct ArcdpsWindowLogger {
+    name: &'static str,
+}
 
 impl log::Log for ArcdpsWindowLogger {
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
@@ -52,7 +63,8 @@ impl log::Log for ArcdpsWindowLogger {
         }
 
         let body = format!(
-            "{}:{} {}: {}\0",
+            "{} - {}:{} {}: {}\0",
+            self.name,
             record.file().unwrap_or_default(),
             record.line().unwrap_or_default(),
             record.level(),


### PR DESCRIPTION
Adds the addon name to the log to easier recognize which message belongs to which addon.

![im](https://user-images.githubusercontent.com/2663045/125201561-0307f600-e270-11eb-9eb3-f161cb07da33.png)

```
Jul 11 17:46:18 Arc-Dll-Test - src\lib.rs:210 INFO: Test message
```