### PR TITLE
Fix ArcDPS color export function

### DIFF
--- a/core/src/raw_structs.rs
+++ b/core/src/raw_structs.rs
@@ -70,7 +70,7 @@ pub type CombatCallback = fn(
 
 pub type Export0 = fn() -> *mut u16;
 pub type Export3 = fn(*mut u8);
-pub type Export5 = fn(*mut [*mut [[f32; 4]]; 5]);
+pub type Export5 = fn(*mut [*mut [f32; 4]; 5]);
 pub type Export6 = fn() -> u64;
 pub type Export7 = fn() -> u64;
 pub type Export8 = Export3;


### PR DESCRIPTION
Currently the `e5` color export function exposed by the bindings takes a mutable pointer to an array of `*mut [[f32; 4]]` as parameter. The problem is, any `*mut [T]` type (special "slice pointer" type) is represented as a fat pointer in memory (see [slice in The Rust Standard Library](https://doc.rust-lang.org/std/primitive.slice.html) or [What is a fat pointer on Stack Overflow](https://stackoverflow.com/questions/57754901/what-is-a-fat-pointer)) akin to a `&mut [T]`. It will span the twice size of a regular pointer since it stores a pointer & length pair.

This results in allocating an 80 byte large structure (on a 64-bit machine) and passing it to ArcDPS, which expects half the size and thus only writes the first 40 bytes. When indexing into the structure, the length bytes are ignored, returning `out[0]` at index 0, `out[2]` at index 1, `out[4]` at index 2 and unchanged (either uninitialized or zeroed) memory at indices 3 & 4. When the user attempts to turn the pointer into a slice the intended way for a `*mut [T]`, `out[1]` & `out[3]` will be interpreted as lengths, causing crashes.

I've changed the signature of `Export5` to use a regular pointer type instead of a slice pointer type. This fixes the memory size discrepancies and also requires the user to explicitly specify a length when turning the pointer into a slice.