### PR TITLE
Prefer ImVec4 over primitive float array

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcdps"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Greaka <mrgreaka@gmail.com>"]
 edition = "2018"
 

--- a/core/src/exported_functions.rs
+++ b/core/src/exported_functions.rs
@@ -27,7 +27,7 @@ pub unsafe fn e3(s: *mut u8) {
 }
 
 static mut E5: Option<Export5> = None;
-pub unsafe fn e5(out: *mut [*mut [[f32; 4]]; 5]) {
+pub unsafe fn e5(out: *mut [*mut imgui::sys::ImVec4; 5]) {
     E5.get_or_insert_with(|| transmute(get_func("e5")))(out)
 }
 

--- a/core/src/raw_structs.rs
+++ b/core/src/raw_structs.rs
@@ -70,7 +70,7 @@ pub type CombatCallback = fn(
 
 pub type Export0 = fn() -> *mut u16;
 pub type Export3 = fn(*mut u8);
-pub type Export5 = fn(*mut [*mut [f32; 4]; 5]);
+pub type Export5 = fn(*mut [*mut imgui::sys::ImVec4; 5]);
 pub type Export6 = fn() -> u64;
 pub type Export7 = fn() -> u64;
 pub type Export8 = Export3;


### PR DESCRIPTION
Following #4, this changes the type of colors retrieved from ArcDPS from a primitve `[f32; 4]` to the more appropriate [`imgui_sys::ImVec4`](https://docs.rs/imgui-sys/0.7.0/imgui_sys/struct.ImVec4.html).
Also includes a version bump. I'm hoping a patch one is sufficient since the ArcDPS export bindings are still a work-in-progress.