### PR TITLE
Reenable ImGui tables API

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ version = "0.7.0"
 [dependencies.imgui]
 package = "arcdps-imgui"
 version = "0.8.0"
+features = ["tables-api"]
 #git = "https://github.com/gw2scratch/imgui-rs"
 #path = "../../imgui-rs/imgui"
 


### PR DESCRIPTION
The newer version of `imgui-rs` used in `arcdps-imgui` now hides everything related to tables behind a feature. This PR adds the feature in order to reenable the tables API. As an alternative, this could also be changed directly in `arcdps-imgui`.